### PR TITLE
allowing the option to generate release notes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "GitHub Token"
     required: false
     default: "${{ github.token }}"
+  generate_release_notes:
+    description: "Generate release notes based on the commits in the tag. Default: `false`"
+    required: false
+    default: false
 outputs:
   id:
     description: "The ID of the created Release"

--- a/dist/index.js
+++ b/dist/index.js
@@ -31817,6 +31817,8 @@ async function run() {
     const draft = core.getInput("draft", { required: false }) === "true";
     const prerelease =
       core.getInput("prerelease", { required: false }) === "true";
+    const generate_release_notes =
+      core.getInput("generate_release_notes", { required: false }) === "true";
     const commitish =
       core.getInput("commitish", { required: false }) || context.sha;
 
@@ -31844,6 +31846,7 @@ async function run() {
       draft,
       prerelease,
       target_commitish: commitish,
+      generate_release_notes,
     });
 
     // Get the ID, html_url, and upload URL for the created Release from the response

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -25,6 +25,8 @@ async function run() {
     const draft = core.getInput("draft", { required: false }) === "true";
     const prerelease =
       core.getInput("prerelease", { required: false }) === "true";
+    const generate_release_notes =
+      core.getInput("generate_release_notes", { required: false }) === "true";
     const commitish =
       core.getInput("commitish", { required: false }) || context.sha;
 
@@ -52,6 +54,7 @@ async function run() {
       draft,
       prerelease,
       target_commitish: commitish,
+      generate_release_notes,
     });
 
     // Get the ID, html_url, and upload URL for the created Release from the response


### PR DESCRIPTION
This pull request introduces a new feature to the release creation process by adding an option to generate release notes based on the commits in the tag. The most important changes include the addition of a new input parameter in the `action.yml` file and updates to the `create-release.js` script to handle this new parameter.

Enhancements to release creation:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R38-R41): Added a new input parameter `generate_release_notes` with a description and default value set to `false`.
* [`src/create-release.js`](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cR28-R29): Updated the `run` function to retrieve the new `generate_release_notes` input and include it in the release creation payload. [[1]](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cR28-R29) [[2]](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cR57)