### PR TITLE
creating gh action for building the action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: npm ci --omit=dev --ignore-scripts
+        run: npm ci --ignore-scripts
       - name: Build using ncc
         run: npm run build
       - name: Commit changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Building Action into a single file using ncc
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_and_commit:
+    name: Build app and commit to repo
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts
+      - name: Build using ncc
+        run: npm run build
+      - name: Commit changes
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Built app using ncc"
+            git push origin HEAD:${{ github.head_ref }}
+          fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,11 @@ inputs:
   draft:
     description: "`true` to create a draft (unpublished) release, `false` to create a published one. Default: `false`"
     required: false
-    default: false
+    default: "false"
   prerelease:
     description: "`true` to identify the release as a prerelease. `false` to identify the release as a full release. Default: `false`"
     required: false
-    default: false
+    default: "false"
   commitish:
     description: "Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit"
     required: false
@@ -38,7 +38,14 @@ inputs:
   generate_release_notes:
     description: "Generate release notes based on the commits in the tag. Default: `false`"
     required: false
-    default: false
+    default: "false"
+  discussion_category_name:
+    description: "The name of the discussion category to associate with the release"
+    required: false
+  make_latest:
+    description: "Make the release the latest release"
+    required: false
+    default: "true"
 outputs:
   id:
     description: "The ID of the created Release"

--- a/src/create-release.js
+++ b/src/create-release.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 
 async function run() {
   try {
-    // Get authenticated GitHub client (Ocktokit): https://github.com/actions/toolkit/tree/master/packages/github#usage
+    // Get authenticated GitHub client (Octokit): https://github.com/actions/toolkit/tree/master/packages/github#usage
     const gh = github.getOctokit(
       core.getInput("github-token", { required: true }),
     );
@@ -15,8 +15,6 @@ async function run() {
 
     // Get the inputs from the workflow file: https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs
     const tagName = core.getInput("tag_name", { required: true });
-
-    // This removes the 'refs/tags' portion of the string, i.e. from 'refs/tags/v1.10.15' to 'v1.10.15'
     const tag = tagName.replace("refs/tags/", "");
     const releaseName = core
       .getInput("release_name", { required: false })
@@ -27,6 +25,11 @@ async function run() {
       core.getInput("prerelease", { required: false }) === "true";
     const generate_release_notes =
       core.getInput("generate_release_notes", { required: false }) === "true";
+    const discussion_category_name = core.getInput("discussion_category_name", {
+      required: false,
+    });
+    const make_latest =
+      core.getInput("make_latest", { required: false }) === "true";
     const commitish =
       core.getInput("commitish", { required: false }) || context.sha;
 
@@ -49,12 +52,14 @@ async function run() {
       owner,
       repo,
       tag_name: tag,
+      target_commitish: commitish,
       name: releaseName,
       body: bodyFileContent || body,
       draft,
       prerelease,
-      target_commitish: commitish,
+      discussion_category_name,
       generate_release_notes,
+      make_latest,
     });
 
     // Get the ID, html_url, and upload URL for the created Release from the response


### PR DESCRIPTION
This pull request introduces several changes to the GitHub Action workflow, configuration files, and the `src/create-release.js` script to enhance functionality and ensure consistency. The most important changes are summarized below:

### Workflow Enhancements:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R31): Added a new GitHub Action workflow to build the application using `ncc` and commit the built files back to the repository. This workflow runs on pull requests targeting the `main` branch.

### Configuration Updates:

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R1-R2): Added `dist` and `node_modules` directories to the `.prettierignore` file to prevent formatting of these directories.

### Input Validation and Consistency:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L20-R24): Updated default values for boolean inputs (`draft`, `prerelease`, `generate_release_notes`) to be strings ("false" or "true") for consistency. Added new inputs `discussion_category_name` and `make_latest` to support additional release options. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L20-R24) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L41-R48)

### Code Improvements:

* [`src/create-release.js`](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cL7-R7): Corrected a typo in the comment (changed "Ocktokit" to "Octokit").
* [`src/create-release.js`](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cL18-L19): Removed an unnecessary comment and added support for new inputs (`discussion_category_name`, `make_latest`) when creating a release. [[1]](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cL18-L19) [[2]](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cR28-R32) [[3]](diffhunk://#diff-7dc5d4d4fd6f7fc9d16913b72ee4f927154aba08ac1deab4ad279b5152838a1cR55-R62)